### PR TITLE
feat: decode null getRawValue

### DIFF
--- a/packages/std-contracts/src/components/AddressBareComponent.sol
+++ b/packages/std-contracts/src/components/AddressBareComponent.sol
@@ -18,7 +18,11 @@ contract AddressBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (address) {
-    address value = abi.decode(getRawValue(entity), (address));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      address value = abi.decode(rawValue, (address));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/AddressComponent.sol
+++ b/packages/std-contracts/src/components/AddressComponent.sol
@@ -18,8 +18,12 @@ contract AddressComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (address) {
-    address value = abi.decode(getRawValue(entity), (address));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      address value = abi.decode(rawValue, (address));
+      return value;
+    }
   }
 
   function getEntitiesWithValue(address value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/BoolBareComponent.sol
+++ b/packages/std-contracts/src/components/BoolBareComponent.sol
@@ -18,7 +18,11 @@ contract BoolBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (bool) {
-    bool value = abi.decode(getRawValue(entity), (bool));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      bool value = abi.decode(rawValue, (bool));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/BoolComponent.sol
+++ b/packages/std-contracts/src/components/BoolComponent.sol
@@ -18,8 +18,12 @@ contract BoolComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (bool) {
-    bool value = abi.decode(getRawValue(entity), (bool));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      bool value = abi.decode(rawValue, (bool));
+      return value;
+    }
   }
 
   function getEntitiesWithValue(bool value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/CoordBareComponent.sol
+++ b/packages/std-contracts/src/components/CoordBareComponent.sol
@@ -26,7 +26,11 @@ contract CoordBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (Coord memory) {
-    (int32 x, int32 y) = abi.decode(getRawValue(entity), (int32, int32));
-    return Coord(x, y);
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      (int32 x, int32 y) = abi.decode(rawValue, (int32, int32));
+      return Coord(x, y);
+    }
   }
 }

--- a/packages/std-contracts/src/components/CoordComponent.sol
+++ b/packages/std-contracts/src/components/CoordComponent.sol
@@ -26,8 +26,12 @@ contract CoordComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (Coord memory) {
-    (int32 x, int32 y) = abi.decode(getRawValue(entity), (int32, int32));
-    return Coord(x, y);
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      (int32 x, int32 y) = abi.decode(rawValue, (int32, int32));
+      return Coord(x, y);
+    }
   }
 
   function getEntitiesWithValue(Coord calldata coord) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/FunctionBareComponent.sol
+++ b/packages/std-contracts/src/components/FunctionBareComponent.sol
@@ -26,7 +26,11 @@ contract FunctionBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (FunctionSelector memory) {
-    return abi.decode(getRawValue(entity), (FunctionSelector));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (FunctionSelector));
+    }
   }
 }
 

--- a/packages/std-contracts/src/components/FunctionComponent.sol
+++ b/packages/std-contracts/src/components/FunctionComponent.sol
@@ -26,7 +26,11 @@ contract FunctionComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (FunctionSelector memory) {
-    return abi.decode(getRawValue(entity), (FunctionSelector));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (FunctionSelector));
+    }
   }
 
   function getEntitiesWithValue(FunctionSelector memory value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/Int32BareComponent.sol
+++ b/packages/std-contracts/src/components/Int32BareComponent.sol
@@ -18,7 +18,11 @@ contract Int32BareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (int32) {
-    int32 value = abi.decode(getRawValue(entity), (int32));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      int32 value = abi.decode(rawValue, (int32));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/Int32Component.sol
+++ b/packages/std-contracts/src/components/Int32Component.sol
@@ -18,8 +18,12 @@ contract Int32Component is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (int32) {
-    int32 value = abi.decode(getRawValue(entity), (int32));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      int32 value = abi.decode(rawValue, (int32));
+      return value;
+    }
   }
 
   function getEntitiesWithValue(int32 value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/StringArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayBareComponent.sol
@@ -18,6 +18,11 @@ contract StringArrayBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (string[] memory) {
-    return abi.decode(getRawValue(entity), (string[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      string[] memory value = abi.decode(rawValue, (string[]));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/StringArrayComponent.sol
+++ b/packages/std-contracts/src/components/StringArrayComponent.sol
@@ -18,7 +18,11 @@ contract StringArrayComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (string[] memory) {
-    return abi.decode(getRawValue(entity), (string[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (string[]));
+    }
   }
 
   function getEntitiesWithValue(string[] memory value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/StringBareComponent.sol
+++ b/packages/std-contracts/src/components/StringBareComponent.sol
@@ -18,7 +18,11 @@ contract StringBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (string memory) {
-    string memory value = abi.decode(getRawValue(entity), (string));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      string memory value = abi.decode(rawValue, (string));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/StringComponent.sol
+++ b/packages/std-contracts/src/components/StringComponent.sol
@@ -18,8 +18,12 @@ contract StringComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (string memory) {
-    string memory value = abi.decode(getRawValue(entity), (string));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      string memory value = abi.decode(rawValue, (string));
+      return value;
+    }
   }
 
   function getEntitiesWithValue(string memory value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
+++ b/packages/std-contracts/src/components/SystemCallbackBareComponent.sol
@@ -34,7 +34,11 @@ contract SystemCallbackBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (SystemCallback memory) {
-    return abi.decode(getRawValue(entity), (SystemCallback));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (SystemCallback));
+    }
   }
 }
 

--- a/packages/std-contracts/src/components/SystemCallbackComponent.sol
+++ b/packages/std-contracts/src/components/SystemCallbackComponent.sol
@@ -25,7 +25,11 @@ contract SystemCallbackComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (SystemCallback memory) {
-    return abi.decode(getRawValue(entity), (SystemCallback));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (SystemCallback));
+    }
   }
 
   function getEntitiesWithValue(SystemCallback memory value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayBareComponent.sol
@@ -18,6 +18,10 @@ contract Uint256ArrayBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint256[] memory) {
-    return abi.decode(getRawValue(entity), (uint256[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (uint256[]));
+    }
   }
 }

--- a/packages/std-contracts/src/components/Uint256ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint256ArrayComponent.sol
@@ -18,7 +18,11 @@ contract Uint256ArrayComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint256[] memory) {
-    return abi.decode(getRawValue(entity), (uint256[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (uint256[]));
+    }
   }
 
   function getEntitiesWithValue(uint256 value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/Uint256BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint256BareComponent.sol
@@ -21,7 +21,11 @@ contract Uint256BareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint256) {
-    uint256 value = abi.decode(getRawValue(entity), (uint256));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      uint256 value = abi.decode(rawValue, (uint256));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayBareComponent.sol
@@ -18,6 +18,10 @@ contract Uint32ArrayBareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint32[] memory) {
-    return abi.decode(getRawValue(entity), (uint32[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (uint32[]));
+    }
   }
 }

--- a/packages/std-contracts/src/components/Uint32ArrayComponent.sol
+++ b/packages/std-contracts/src/components/Uint32ArrayComponent.sol
@@ -18,7 +18,11 @@ contract Uint32ArrayComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint32[] memory) {
-    return abi.decode(getRawValue(entity), (uint32[]));
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      return abi.decode(rawValue, (uint32[]));
+    }
   }
 
   function getEntitiesWithValue(uint32[] memory value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/Uint32BareComponent.sol
+++ b/packages/std-contracts/src/components/Uint32BareComponent.sol
@@ -18,7 +18,11 @@ contract Uint32BareComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint32) {
-    uint32 value = abi.decode(getRawValue(entity), (uint32));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      uint32 value = abi.decode(rawValue, (uint32));
+      return value;
+    }
   }
 }

--- a/packages/std-contracts/src/components/Uint32Component.sol
+++ b/packages/std-contracts/src/components/Uint32Component.sol
@@ -18,8 +18,12 @@ contract Uint32Component is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (uint32) {
-    uint32 value = abi.decode(getRawValue(entity), (uint32));
-    return value;
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      uint32 value = abi.decode(rawValue, (uint32));
+      return value;
+    }
   }
 
   function getEntitiesWithValue(uint32 value) public view virtual returns (uint256[] memory) {

--- a/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordBareComponent.sol
@@ -30,7 +30,11 @@ contract VoxelCoordComponent is BareComponent {
   }
 
   function getValue(uint256 entity) public view virtual returns (VoxelCoord memory) {
-    (int32 x, int32 y, int32 z) = abi.decode(getRawValue(entity), (int32, int32, int32));
-    return VoxelCoord(x, y, z);
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      (int32 x, int32 y, int32 z) = abi.decode(rawValue, (int32, int32, int32));
+      return VoxelCoord(x, y, z);
+    }
   }
 }

--- a/packages/std-contracts/src/components/VoxelCoordComponent.sol
+++ b/packages/std-contracts/src/components/VoxelCoordComponent.sol
@@ -30,8 +30,12 @@ contract VoxelCoordComponent is Component {
   }
 
   function getValue(uint256 entity) public view virtual returns (VoxelCoord memory) {
-    (int32 x, int32 y, int32 z) = abi.decode(getRawValue(entity), (int32, int32, int32));
-    return VoxelCoord(x, y, z);
+    bytes memory rawValue = getRawValue(entity);
+
+    if (rawValue.length > 0) {
+      (int32 x, int32 y, int32 z) = abi.decode(rawValue, (int32, int32, int32));
+      return VoxelCoord(x, y, z);
+    }
   }
 
   function getEntitiesWithValue(VoxelCoord calldata coord) public view virtual returns (uint256[] memory) {


### PR DESCRIPTION
Don't revert on null getRawValue. Retreiving data from components should behave similarly to reading from mappings. If revert is intended, getValue should revert with custom a error.